### PR TITLE
Add colons to the alternative text as well

### DIFF
--- a/emoji-images.js
+++ b/emoji-images.js
@@ -20,7 +20,7 @@
         return someString.replace(test, function (match) {
             if (emojis.indexOf(match) !== -1) {
                 var name = String(match).slice(1, -1);
-                return '<img class="emoji" title=":' + name + ':" alt="' + name + '" src="' + url + '/' + encodeURIComponent(name) + '.png"' + (size ? (' height="' + size + '"') : '') + ' />';
+                return '<img class="emoji" title=":' + name + ':" alt=":' + name + ':" src="' + url + '/' + encodeURIComponent(name) + '.png"' + (size ? (' height="' + size + '"') : '') + ' />';
             } else {
                 return match;
             }


### PR DESCRIPTION
From downstream package frissdiegurke/nodebb-plugin-emoji-extended#5:

We're experiencing problems when users copy and paste emojified text. The emoji embedded does not contain the colons as expected, so when _re-pasted_ back into a textarea that will get emojified, the emoji itself is missed.

Raw: `Some text with emoji :ice_cream: :hatched_chick:`
Emojified: Some text with emoji :ice_cream: :hatched_chick:
Copied into clipboard: `Some text with emoji ice_cream hatched_chick`
Pasted & re-emojified: Some text with emoji ice_cream hatched_chick
